### PR TITLE
ファイルの変更を自動検知してPDF ファイルを出力するように改修

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,11 +3,13 @@ MAINTAINER Tsutomu Nakamura<tsuna.0x00@gmail.com>
 
 RUN apt-get update && \
         DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
-        DEBIAN_FRONTEND=noninteractive apt-get install -y inotify-tools
+        DEBIAN_FRONTEND=noninteractive apt-get install -y inotify-tools && \
+        apt-get autoclean -y && \
+        rm -rf /var/lib/apt/lists/*
 
 COPY entrypoint.sh /opt/entrypoint.sh
 
 RUN chmod 755 /opt/entrypoint.sh
 
-ENTRYPOINT [/opt/entrypoint.sh]
+ENTRYPOINT "/opt/entrypoint.sh"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,13 @@
+FROM kauplan/review2.5
+MAINTAINER Tsutomu Nakamura<tsuna.0x00@gmail.com>
+
+RUN apt-get update && \
+        DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
+        DEBIAN_FRONTEND=noninteractive apt-get install -y inotify-tools
+
+COPY entrypoint.sh /opt/entrypoint.sh
+
+RUN chmod 755 /opt/entrypoint.sh
+
+ENTRYPOINT [/opt/entrypoint.sh]
+

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,52 +2,61 @@
 
 WORK_DIR="/root/grouscope-books"
 DESTINATION="mybook.pdf"
+EMOJI_POPPER="🎉"
+EMOJI_SORROWLY="😱"
+EMOJI_GLASS="🧐"
 
 main() {
 
     cd "$WORK_DIR"
-    if [[ ! -f "$DESTINATION" ]]; then
-        rake pdf
-        echo "$(date +%Y%m%d %H:%M:%S) 初期ファイルを作成しました"
-    fi
 
-    declare -A last_files_of_stats
+    rake pdf
+    echo "$(date "+%Y/%m/%d %H:%M:%S") INFO: ${EMOJI_POPPER}初期ファイルを作成しました${EMOJI_POPPER} [File: ${DESTINATION}]"
+    echo "$(date "+%Y/%m/%d %H:%M:%S") INFO: モニタリングを開始しました${EMOJI_GLASS}。Re:VIEW ファイルの追加/削除/変更を監視して自動でPDF ファイルを出力します"
 
     # ファイルキャッシュリストを作成する
+    declare -A last_files_of_stats
     local file
+    local hash_value
     while read file; do
-        last_files_of_stats=true
+        hash_value="$(sha1sum "$file" 2> /dev/null | cut -d ' ' -f 1)"
+        last_files_of_stats["$file"]="$hash_value"
     done < <(find . -name "*.re" -type f | sed -e 's|^\./||')
 
     local path
     local action
-    local file
-    local hash_value
     local last_hash_value
     local result_of_rake
-    inotifywait -m /root/grouscope-books -e create -e move -e delete |
-            while read path action file; do
-                if [[ "$file" =~ .*\.re$ ]]; then
-                    if [[ "$action" == "MOVED_FROM" ]] || [[ "$action" == "DELETE" ]]; then
-                        [[ ! -f "$file" ]] && unset last_files_of_stats["$file"]
-                    fi
 
-                    hash_value="$(sha1sum "$file" | cut -d ' ' -f 1)"
-                    #echo "Last_hash: ${last_files_of_stats["$file"]}, Current_hash: $hash_value, File: $file"
-                    if [[ "${last_files_of_stats["$file"]}" != "$hash_value" ]]; then
-                        echo "##### rake pdf -- File: $file, Action: $action"
-                        last_hash_value="${last_files_of_stats["$file"]}"
-                        last_files_of_stats["$file"]="$hash_value"
-                        rake pdf
-                        result_of_rake=$?
-                        if [[ $result_of_rake -eq 0 ]]; then
-                            echo "INFO: ビルドが成功しました[トリガ: File: $file, Action: $action, last_hash: ${last_hash_value:0:7}, current_hash: ${hash_value:0:7}]"
-                        else
-                            echo "ERROR: ビルドに失敗しました[トリガ: File: $file, Action: $action, last_hash: ${last_hash_value:0:7}, current_hash: ${hash_value:0:7}]" >&2
-                        fi
-                    fi
+    while read path action file; do
+        # echo "File: $file, Action: $action"    # debug
+        if [[ "$file" =~ .*\.re$ ]]; then
+            last_hash_value="${last_files_of_stats["$file"]}"
+            hash_value="$(sha1sum "$file" 2> /dev/null | cut -d ' ' -f 1)"
+
+            if [[ "$action" == "MOVED_FROM" ]] || [[ "$action" == "DELETE" ]]; then
+                [[ ! -f "$file" ]] && unset last_files_of_stats["$file"]
+            fi
+
+            # echo "Last_hash: $last_hash_value, Current_hash: $hash_value, File: $file"    # debug
+            if [[ "$last_hash_value" != "$hash_value" ]]; then
+                if [[ ! -z "$hash_value" ]]; then
+                    last_files_of_stats["$file"]="$hash_value"
                 fi
-            done
+
+                echo "$(date "+%Y/%m/%d %H:%M:%S") INFO: rake pdf -- File: $file, Action: $action, Hash: ${hash_value:0:7}"
+                rake pdf
+                result_of_rake=$?
+                echo "============================================================================="
+                if [[ $result_of_rake -eq 0 ]]; then
+                    echo "$(date "+%Y/%m/%d %H:%M:%S") INFO: ${EMOJI_POPPER}ビルドが成功しました${EMOJI_POPPER}[トリガ: File: $file, Action: $action, last_hash: ${last_hash_value:0:7}, current_hash: ${hash_value:0:7}, out: mybook.pdf]"
+                else
+                    echo "$(date "+%Y/%m/%d %H:%M:%S") ERROR: ${EMOJI_SORROWLY}ビルドに失敗しました${EMOJI_SORROWLY}[トリガ: File: $file, Action: $action, last_hash: ${last_hash_value:0:7}, current_hash: ${hash_value:0:7}]" >&2
+                fi
+                echo "============================================================================="
+            fi
+        fi
+    done < <(inotifywait -m /root/grouscope-books -e create -e move -e delete)
 }
 
 main "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+WORK_DIR="/root/grouscope-books"
+DESTINATION="mybook.pdf"
+
+main() {
+
+    cd "$WORK_DIR"
+    if [[ ! -f "$DESTINATION" ]]; then
+        rake pdf
+        echo "$(date +%Y%m%d %H:%M:%S) 初期ファイルを作成しました"
+    fi
+
+    declare -A last_files_of_stats
+
+    # ファイルキャッシュリストを作成する
+    local file
+    while read file; do
+        last_files_of_stats=true
+    done < <(find . -name "*.re" -type f | sed -e 's|^\./||')
+
+    local path
+    local action
+    local file
+    local hash_value
+    local last_hash_value
+    local result_of_rake
+    inotifywait -m /root/grouscope-books -e create -e move -e delete |
+            while read path action file; do
+                if [[ "$file" =~ .*\.re$ ]]; then
+                    if [[ "$action" == "MOVED_FROM" ]] || [[ "$action" == "DELETE" ]]; then
+                        [[ ! -f "$file" ]] && unset last_files_of_stats["$file"]
+                    fi
+
+                    hash_value="$(sha1sum "$file" | cut -d ' ' -f 1)"
+                    #echo "Last_hash: ${last_files_of_stats["$file"]}, Current_hash: $hash_value, File: $file"
+                    if [[ "${last_files_of_stats["$file"]}" != "$hash_value" ]]; then
+                        echo "##### rake pdf -- File: $file, Action: $action"
+                        last_hash_value="${last_files_of_stats["$file"]}"
+                        last_files_of_stats["$file"]="$hash_value"
+                        rake pdf
+                        result_of_rake=$?
+                        if [[ $result_of_rake -eq 0 ]]; then
+                            echo "INFO: ビルドが成功しました[トリガ: File: $file, Action: $action, last_hash: ${last_hash_value:0:7}, current_hash: ${hash_value:0:7}]"
+                        else
+                            echo "ERROR: ビルドに失敗しました[トリガ: File: $file, Action: $action, last_hash: ${last_hash_value:0:7}, current_hash: ${hash_value:0:7}]" >&2
+                        fi
+                    fi
+                fi
+            done
+}
+
+main "$@"
+

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -56,7 +56,7 @@ main() {
                 echo "============================================================================="
             fi
         fi
-    done < <(inotifywait -m /root/grouscope-books -e create -e move -e delete)
+    done < <(inotifywait -m /root/grouscope-books -e create -e move -e delete -e modify)
 }
 
 main "$@"

--- a/watch.sh
+++ b/watch.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+IMAGE="a6scloud/grouscope-books"
+TAG="latest"
+#TAG="testing"
+
+main() {
+    local opt="$1"
+    local script_dir=
+
+    # このスクリプトがあるディレクトリに移動する
+    cd "$( dirname "${BASH_SOURCE[0]}" )"
+
+    if [[ "$opt" == "-d" ]]; then
+        docker run --rm --name grouscope_books \
+                --volume "${PWD}:/root/grouscope-books" -d ${IMAGE}:${TAG}
+    else
+        docker run --rm --name grouscope_books \
+                --volume "${PWD}:/root/grouscope-books" -ti ${IMAGE}:${TAG}
+    fi
+}
+
+main "$@"

--- a/watch.sh
+++ b/watch.sh
@@ -6,7 +6,6 @@ TAG="latest"
 
 main() {
     local opt="$1"
-    local script_dir=
 
     # このスクリプトがあるディレクトリに移動する
     cd "$( dirname "${BASH_SOURCE[0]}" )"


### PR DESCRIPTION
# 対応内容
#6 の内容に対応しました。

# 確認方法
watch.sh のTAG 変数をtesting に設定します。
```
TAG="testing"
```

watch.sh を実行します。docker イメージをpull してくるので初回は時間かかります。

```
2019/07/27 12:53:47 INFO: 🎉初期ファイルを作成しました🎉 [File: mybook.pdf]
2019/07/27 12:53:47 INFO: モニタリングを開始しました🧐。Re:VIEW ファイルの追加/削除/変更を監視して自動でPDF ファイルを出力します
```
上記メッセージが出たらモニタリングモード開始です。別ターミナルやテキストエディタを開き、適当なRe:VIEW ファイル(拡張子.re のファイル)を編集したり削除したり追加することでビルドが自動的に走ることを確認してください。以下はビルドが正常終了した時のメッセージ例です。(注: 今の所トップディレクトリのRe:VIEW ファイルだけ監視しています。サブディレクトリにRe:VIEW ファイルを作成したりしても自動ビルドは走りません…)

```
2019/07/27 12:55:26 INFO: 🎉ビルドが成功しました🎉[トリガ: File: chap02.re, Action: CREATE, last_hash: 003723e, current_hash: cfb5186, out: mybook.pdf]
```

# クローズするissue
close #6 

# このタスクで発生したissue
なし

# その他
本プルリク確認後、watch.sh の変数は戻しておいてください。
```
TAG="latest"
```

本プルリクエストマージ後、30分程するとmaster ブランチからもwatch.sh で自動ビルドができるようになると思います。